### PR TITLE
Calculate loss on dynamically checked nb of GPUs for small batches

### DIFF
--- a/transformer/multi_gpu_loss_compute.py
+++ b/transformer/multi_gpu_loss_compute.py
@@ -13,18 +13,21 @@ class MultiGPULossCompute(object):
 
     def __init__(self, generator, criterion, devices, opt=None, chunk_size=5):
         # Send out to different gpus.
-        self.generator = generator
-        self.criterion = nn.parallel.replicate(criterion, devices=devices)
+        self.criteria = [nn.parallel.replicate(criterion, devices=devices[:i + 1]) for i in range(len(devices))]
+        self.generators = [nn.parallel.replicate(generator, devices=devices[:i + 1]) for i in range(len(devices))]
+
         self.opt = opt
         self.devices = devices
         self.chunk_size = chunk_size
 
     def __call__(self, out, target, normalize):
         total = 0.0
-        generator = nn.parallel.replicate(self.generator, devices=self.devices)
         out_scatter = nn.parallel.scatter(out, target_gpus=self.devices)
         out_grad = [[] for _ in out_scatter]
         targets = nn.parallel.scatter(target, target_gpus=self.devices)
+
+        generator = self.generators[len(out_scatter) - 1]
+        criterion = self.criteria[len(out_scatter) - 1]
 
         # Divide generating into chunks.
         chunk_size = self.chunk_size
@@ -37,7 +40,7 @@ class MultiGPULossCompute(object):
             # Compute loss.
             y = [(g.contiguous().view(-1, g.size(-1)), t[:, i:i + chunk_size].contiguous().view(-1)) for g, t in
                  zip(gen, targets)]
-            loss = nn.parallel.parallel_apply(self.criterion, y)
+            loss = nn.parallel.parallel_apply(criterion, y)
 
             # Sum and normalize loss
             l = nn.parallel.gather(loss, target_device=self.devices[0])
@@ -45,7 +48,7 @@ class MultiGPULossCompute(object):
             if l.shape == torch.Size([]):  # handle 1 GPU case
                 total += l.item() / normalize
             else:
-                l = l[0] / normalize  
+                l = l[0] / normalize
                 total += l.data[0]
 
             # Backprop loss to output of transformer


### PR DESCRIPTION
This fixes https://github.com/ictnlp-wshugen/annotated-transformer_codes/issues/4. 

I don't know how bad it is for performance (eg how much memory it takes) to replicate the `generator` and `criterion` several times. That's way in the code they are replicated _as needed_. If this is not necessary we can just replicate them over all nb of devices at the start (like in the first commit).